### PR TITLE
Add homepage layout

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -1,4 +1,5 @@
 import Head from 'next/head'
+import styles from '../styles/Home.module.css'
 
 export default function Home() {
   return (
@@ -7,10 +8,42 @@ export default function Home() {
         <title>WoojinChemical</title>
         <meta name="description" content="우진케미칼 웹사이트" />
       </Head>
-
-      <div style={{ padding: '2rem', textAlign: 'center' }}>
-        <h1>Welcome to WoojinChemical</h1>
-        <p>우진케미칼에 오신 것을 환영합니다!</p>
+      <div className={styles['chem-container']}>
+        <header className={styles['chem-nav']}>
+          <nav>
+            <ul className={styles['chem-nav-list']}>
+              <li><a href="#intro">Company</a></li>
+              <li><a href="#products">Products</a></li>
+              <li><a href="#contact">Contact</a></li>
+            </ul>
+          </nav>
+        </header>
+        <section className={styles['chem-hero']}>
+          <h1>Welcome to WoojinChemical</h1>
+          <p>Leading innovations in chemical solutions.</p>
+        </section>
+        <section id="intro" className={styles['chem-intro']}>
+          <h2>About Us</h2>
+          <p>WoojinChemical is committed to providing high-quality chemical products to industries worldwide. Our team of experts ensures safe and efficient solutions tailored to your needs.</p>
+        </section>
+        <section id="products" className={styles['chem-products']}>
+          <h2>Our Products</h2>
+          <ul className={styles['chem-products-list']}>
+            <li className={styles['chem-product-item']}>Industrial Solvents</li>
+            <li className={styles['chem-product-item']}>Cleaning Agents</li>
+            <li className={styles['chem-product-item']}>Custom Formulations</li>
+          </ul>
+        </section>
+        <section id="contact" className={styles['chem-contact']}>
+          <h2>Contact Us</h2>
+          <form>
+            <label htmlFor="name">Name</label>
+            <input id="name" type="text" />
+            <label htmlFor="message">Message</label>
+            <textarea id="message" rows="4"></textarea>
+            <button type="submit">Send</button>
+          </form>
+        </section>
       </div>
     </>
   )

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -1,0 +1,58 @@
+.chem-container {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+}
+
+.chem-nav {
+  background-color: #004080;
+  color: white;
+  padding: 1rem;
+}
+
+.chem-nav-list {
+  list-style: none;
+  display: flex;
+  justify-content: space-around;
+  margin: 0;
+  padding: 0;
+}
+
+.chem-hero {
+  background-color: #e0f0ff;
+  text-align: center;
+  padding: 4rem 1rem;
+}
+
+.chem-intro,
+.chem-products,
+.chem-contact {
+  padding: 2rem 1rem;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.chem-products-list {
+  list-style: none;
+  padding: 0;
+}
+
+.chem-product-item {
+  margin-bottom: 1rem;
+}
+
+.chem-contact form {
+  display: flex;
+  flex-direction: column;
+}
+
+.chem-contact label {
+  margin-bottom: 0.5rem;
+}
+
+.chem-contact input,
+.chem-contact textarea {
+  margin-bottom: 1rem;
+  padding: 0.5rem;
+}
+


### PR DESCRIPTION
## Summary
- create `Home.module.css` with `chem-` prefixed classes
- build a homepage layout with navbar, hero, intro, products, and contact sections using prefixed classes

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e1e856bb0833289c1fba6e9eb666b